### PR TITLE
Add Firefox (mozilla/gecko-dev)

### DIFF
--- a/mozilla-gecko-dev/.gitpod
+++ b/mozilla-gecko-dev/.gitpod
@@ -2,9 +2,3 @@ image: janitortechnology/firefox
 ports:
   - port: 8088
     protocol: "http"
-  - port: 8089
-    protocol: "http"
-  - port: 8090
-    protocol: "http"
-checkoutLocation: "/home/user/firefox"
-workspaceLocation: "/home/user/firefox"

--- a/mozilla-gecko-dev/.gitpod
+++ b/mozilla-gecko-dev/.gitpod
@@ -1,0 +1,10 @@
+image: janitortechnology/firefox
+ports:
+  - port: 8088
+    protocol: "http"
+  - port: 8089
+    protocol: "http"
+  - port: 8090
+    protocol: "http"
+checkoutLocation: "/home/user/firefox"
+workspaceLocation: "/home/user/firefox"


### PR DESCRIPTION
In this pull request, I attempt to support Firefox development (using the official Git mirror https://github.com/mozilla/gecko-dev).

The exposed ports come from the Docker image [janitortechnology/firefox](https://github.com/JanitorTechnology/dockerfiles/blob/master/firefox/firefox-git.dockerfile) (which is based on [janitortechnology/ubuntu-dev](https://github.com/JanitorTechnology/dockerfiles/blob/master/ubuntu-dev/ubuntu-dev.dockerfile)):
- `8088`: noVNC port (for a graphical X environment to run and test `firefox` in)
- `8089`: the Cloud9 web IDE (may not be necessary with gitpod since you already have Theia)
- `8090`: the Theia web IDE (same)

Note: The image already includes a Git checkout of Firefox at `/home/user/firefox`, and it's even already pre-compiled. But maybe it can be overwritten by gitpod with a fresh clone (e.g. to check out a particular branch or commit).

I haven't been able to test this configuration file. Please advise on how to do that. (I've tested gitpod on `mozilla/gecko-dev` directly, but wasn't able to build Firefox, because gitpod's default image is missing some packages, and trying to install them via `./mach bootstrap` didn't work because I can't `sudo`).