### PR TITLE
Remove experimental gecko-dev configuration until it works.

### DIFF
--- a/gecko-dev/.gitpod
+++ b/gecko-dev/.gitpod
@@ -1,4 +1,0 @@
-image: janitortechnology/firefox
-ports:
-  - port: 8088
-    protocol: "http"


### PR DESCRIPTION
Apologies for the untested configuration file -- it appears that Gitpod is not able to start a workspace with that image:

- Gitpod seems to time out on "Building Workspace Image (1/5)" in the loading screen
- It then shows "Ready", but doesn't go to the IDE, and https://gitpod.io shows the workspace as "Last run a few seconds ago" (i.e. no longer "Running")
- Sometimes when I refresh the stuck "Ready" screen, I briefly see a timeout error before it tries again, although I'm not sure if that's related

Anyway, let's remove this experimental file again, until I've managed to make it work in a dedicated branch of my `gecko-dev` fork.