### PR TITLE
update jhipster-sample-app gitpod config to use npm instead of yarn

### DIFF
--- a/jhipster-sample-app/.gitpod
+++ b/jhipster-sample-app/.gitpod
@@ -6,4 +6,4 @@ ports:
   - port: 3001
     protocol: "http"
 tasks:
-  - command: "yarn install && ./mvnw"
+  - command: "npm install && ./mvnw"


### PR DESCRIPTION
Hi,

Thanks for supporting JHipster out of the box ! I'm proposing a small change to use npm instead of yarn as the JHipster project recently chose to set npm as the default js package manager.