### PR TITLE
Remove `chromite` from Chromium's third party dependencies

### DIFF
--- a/chromium/.gclient
+++ b/chromium/.gclient
@@ -3,7 +3,7 @@ solutions = [
     "url": "https://github.com/chromium/chromium.git",
     "managed": False,
     "name": "src",
-    "custom_deps": {},
+    "custom_deps": { "src/third_party/chromite": None },
     "custom_vars": {},
   },
 ]


### PR DESCRIPTION
It's causing a circular symlink error in Gitpod:

> chromium/src/third_party/chromite/venv/chromite/.../venv/chromite: too many levels of symbolic links