### PR TITLE
[vscode] fix libgconf2 package

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -2,5 +2,5 @@ FROM gitpod/workspace-full-vnc:latest
 
 # install dependencies
 RUN apt-get update \
-    && apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev libgconf2-4 libnss3 libgtk-3-dev libasound2-dev twm \
+    && apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev libgconf2-dev libnss3 libgtk-3-dev libasound2-dev twm \
     && apt-get clean && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*


### PR DESCRIPTION
After upgrading to latest ubuntu disco, the package was renamed from libgconf2-4 to libgconf2-dev.