### PR TITLE
fix(vscode): Incompatible module errors due to old nodejs

### DIFF
--- a/vscode/.gitpod.yml
+++ b/vscode/.gitpod.yml
@@ -3,5 +3,5 @@ image:
 ports:
   - port: 6080
 tasks:
-  - init: yarn
+  - init: nvm install v10.19.0 --reinstall-packages-from=node && yarn
     command: ./scripts/code.sh


### PR DESCRIPTION
`playwright@1.8.0` requires node `v10.17.0`.
While afterwards `got@11.8.1` wants node `v10.19.0` to satisfy it.