### PR TITLE
vscode/Dockerfile: Add sudo, leave /tmp alone

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -1,6 +1,6 @@
 FROM gitpod/workspace-full-vnc:latest
 
 # install dependencies
-RUN apt-get update \
-    && apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev libgconf2-dev libnss3 libgtk-3-dev libasound2-dev twm \
-    && apt-get clean && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
+RUN sudo apt-get update \
+    && sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev libgconf2-dev libnss3 libgtk-3-dev libasound2-dev twm \
+    && sudo apt-get clean && sudo rm -rf /var/cache/apt/* /var/lib/apt/lists/*


### PR DESCRIPTION
The official gitpod Docker images drop root now, so add sudo
throughout.

Also, don't try to clear out /tmp: we're using tmpfs now, and
you never know when something is actually using /tmp while the system
is still running, so it's both safer and faster to just leave it.

Tested at: https://github.com/SamB/vscode/commit/65df82546e7869e5c9c2dbc545d8e4b9e9862939